### PR TITLE
fix: add missing headers to image_tool

### DIFF
--- a/modules/oci-build/image_tool/append_layers.go
+++ b/modules/oci-build/image_tool/append_layers.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (

--- a/modules/oci-build/image_tool/main.go
+++ b/modules/oci-build/image_tool/main.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (


### PR DESCRIPTION
Make verify fails due to the headers missing from the go files, this adds them